### PR TITLE
#Go# 规范1.1.2条修订建议

### DIFF
--- a/Go安全指南.md
+++ b/Go安全指南.md
@@ -94,7 +94,7 @@ func (p *Packet) UnmarshalBinary(b []byte) error {
     p.PackeyType = b[0]
     p.PackeyVersion = b[1]
   
-    // 若长度等于2，那么不会new Data
+    // 若长度小于等于2，那么不会new Data
     if len(b) > 2 {
         p.Data = new(Data)
         // Unmarshal(b[i:], p.Data)


### PR DESCRIPTION
内容：
1、问题描述
Go代码安全规范的【1.1.2条】nil指针判断部分代码注释有误，需修正

2、解决建议
应修改为 `若长度小于等于2，那么不会new Data`
